### PR TITLE
Update bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ structopt = "0.3"
 [build-dependencies]
 cc = "1.0"
 rand = "0.6"
-bindgen = "0.52"
+bindgen = "0.66"
 pkg-config = { version = "0.3", optional = true }
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -61,8 +61,8 @@ fn main() {
         let bindings = builder
             .header("xdelta3/xdelta3/xdelta3.h")
             .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-            .whitelist_function("xd3_.*")
-            .whitelist_type("xd3_.*")
+            .allowlist_function("xd3_.*")
+            .allowlist_type("xd3_.*")
             .rustified_enum("xd3_.*")
             .generate()
             .expect("Unable to generate bindings");


### PR DESCRIPTION
The current v0.52 version of bindgen causes issues when compiling alongside other crates that use a newer version of bindgen. The reason for the incompatibility is bindgen's dependency on `clang-sys`, of which there can only be one copy per project. Bindgen moved to using `clang-sys` in v0.55.0 (see [v0.54.0](https://crates.io/crates/bindgen/0.54.0/dependencies) vs [v0.55.0](https://crates.io/crates/bindgen/0.55.0/dependencies)), so all versions of bindgen >= v0.55 are compatible with each other.